### PR TITLE
Fix link to array macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 
 ##### Array
 * [`any`](#any)
-* [`array`](#array)
+* [`array`](#array-1)
 * [`collect`](#collect)
 * [`compact`](#compact)
 * [`contains`](#contains)


### PR DESCRIPTION
 The `array` anchor is automatically set up by the `Array`heading on line 32, making the following heading with the same name become `array-1`.