### PR TITLE
add babel plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,5 +2,17 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-awesome-macros'
+  name: 'ember-awesome-macros',
+
+  included: function(app) {
+    this._super.included.apply(this, arguments);
+
+    var babel = app.options.babel;
+    babel.plugins = babel.plugins || [];
+    babel.plugins.push('babel-plugin-fake-import-specifiers');
+    babel.extra = babel.extra || {};
+    babel.extra['fake-import-specifiers'] = [
+      'ember-awesome-macros/math'
+    ];
+  }
 };

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "ember-addon"
   ],
   "dependencies": {
+    "babel-plugin-fake-import-specifiers": "^1.0.0",
     "ember-cli-babel": "^5.1.7",
     "ember-macro-helpers": "0.2.0"
   },

--- a/tests/acceptance/application-test.js
+++ b/tests/acceptance/application-test.js
@@ -1,0 +1,12 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | application');
+
+test('can babel transform expected imports', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(find('.math-test').text().trim(), '1');
+  });
+});

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+import { ceil } from 'ember-awesome-macros/math';
+
+export default Ember.Controller.extend({
+  ceil: ceil(0.5)
+});

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,0 +1,1 @@
+<div class="math-test">{{ceil}}</div>


### PR DESCRIPTION
To support `import { ceil } from 'ember-awesome-macros/math';` even though `ceil` doesn't exist on it's own because it's a dynamic math object export. Babel rewrites this to something like ``import uniqueVar from 'ember-awesome-macros/math';`` and also changes `ceil('xxx')` to `uniqueVar.ceil('xxx')`.