### PR TITLE
Return a sorted copy from `array.sort()`

### DIFF
--- a/addon/array/sort.js
+++ b/addon/array/sort.js
@@ -8,7 +8,7 @@ export default function(array, sortDefinition) {
   let computedCallback;
 
   if (sortDefinition === undefined) {
-    computedCallback = array => array.sort();
+    computedCallback = array => array.slice().sort();
   } else {
     computedCallback = function(array, sortDefinition) {
       let sortCallback;
@@ -38,7 +38,7 @@ export default function(array, sortDefinition) {
         };
       }
 
-      return array.sort(sortCallback);
+      return array.slice().sort(sortCallback);
     };
   }
 

--- a/tests/integration/array/sort-test.js
+++ b/tests/integration/array/sort-test.js
@@ -1,4 +1,5 @@
 import { sort } from 'ember-awesome-macros/array';
+import { raw } from 'ember-awesome-macros';
 import { A as emberA } from 'ember-array/utils';
 import { module, test } from 'qunit';
 import sinon from 'sinon';
@@ -14,7 +15,7 @@ test('it returns undefined if array undefined', function(assert) {
   });
 });
 
-test('it calls sort on array without a parameter', function(assert) {
+test('it returns a sorted array without a parameter', function(assert) {
   compute({
     assert,
     computed: sort('array'),
@@ -25,7 +26,7 @@ test('it calls sort on array without a parameter', function(assert) {
   });
 });
 
-test('it calls sort on array with an array parameter', function(assert) {
+test('it returns a sorted array with an array parameter', function(assert) {
   compute({
     assert,
     computed: sort('array', 'sortDefinition'),
@@ -58,7 +59,18 @@ test('it calls sort on array with an array parameter', function(assert) {
   });
 });
 
-test('it calls sort on array with function parameter', function(assert) {
+test('it returns a sorted array with a direct array parameter', function(assert) {
+  compute({
+    assert,
+    computed: sort('array', ['prop:desc']),
+    properties: {
+      array: [{prop: 1}, {prop: 3}, {prop: 2}]
+    },
+    deepEqual: [{prop: 3}, {prop: 2}, {prop: 1}]
+  });
+});
+
+test('it returns a sorted array with function parameter', function(assert) {
   let sortDefinition = sinon.stub().returns(1);
 
   compute({
@@ -143,4 +155,38 @@ test('the callback is passed the correct args', function(assert) {
       key2: 'xyz'
     }
   ]]);
+});
+
+test('it does not sort the source array for default sorts', function(assert) {
+  let array = [1, 3, 2];
+  compute({
+    assert,
+    computed: sort('array'),
+    properties: {
+      array
+    },
+    deepEqual: [1, 2, 3]
+  });
+  assert.deepEqual(array, [1, 3, 2]);
+});
+
+test('it does not sort the source array for property sorts', function(assert) {
+  let array = [{prop: 1}, {prop: 3}, {prop: 2}];
+  compute({
+    assert,
+    computed: sort('array', ['prop:desc']),
+    properties: {
+      array
+    },
+    deepEqual: [{prop: 3}, {prop: 2}, {prop: 1}]
+  });
+  assert.deepEqual(array, [{prop: 1}, {prop: 3}, {prop: 2}]);
+});
+
+test('composable: it returns a sorted array', function(assert) {
+  compute({
+    assert,
+    computed: sort(raw([1, 3, 2])),
+    deepEqual: [1, 2, 3]
+  });
 });


### PR DESCRIPTION
Fixes #249 

Note: `sort()` currently returns `undefined` when the observed property is undefined, while [Ember's `computed.sort()` returns an empty array](https://github.com/emberjs/ember.js/blob/v2.11.0/packages/ember-runtime/lib/computed/reduce_computed_macros.js#L713). Not sure if this difference is intended, I found it a bit surprising.

At the moment, it seems [`array/-utils.normalizeArray` will accept a static default value](https://github.com/kellyselden/ember-awesome-macros/blob/master/addon/array/-utils.js#L26), but I think we'd want to use a factory function that generates default values (new `Array` objects, in this case). Changing the `normalizeArray` API seems a bit outside the scope of this PR, so I haven't actually touched this, but have added a test for the current behavior (returning `undefined`) and a skipped test for the (in my mind) expected behavior (returning an empty Array).

Happy to open another issue/PR to address this if it's something you'd like changed.