### PR TITLE
add array.rejectBy

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 * [`array.objectAt`](#arrayobjectat)
 * [`array.reduce`](#arrayreduce)
 * [`array.reverse`](#arrayreverse)
+* [`array.rejectBy`](#arrayrejectby)
 * [`array.slice`](#arrayslice)
 * [`array.sort`](#arraysort)
 * [`array.uniqBy`](#arrayuniqby)
@@ -393,6 +394,15 @@ value2: array.reduce(
   //initial value is an array because it is not mutated
   []
 ) // ['one', 0, 'two', 1]
+```
+
+##### `array.rejectBy`
+wraps [`Ember.Array.rejectBy`](http://emberjs.com/api/classes/Ember.Array.html#method_rejectBy), allows composing
+
+```js
+array: Ember.A([{ test: 1 }, { test: 2 }]),
+key: 'test',
+value: array.rejectBy('array', 'key', 2) // [{ test: 1 }]
 ```
 
 ##### `array.reverse`

--- a/addon/array/index.js
+++ b/addon/array/index.js
@@ -20,6 +20,7 @@ export { default as mapBy } from './map-by';
 export { default as map } from './map';
 export { default as objectAt } from './object-at';
 export { default as reduce } from './reduce';
+export { default as rejectBy } from './reject-by';
 export { default as reverse } from './reverse';
 export { default as slice } from './slice';
 export { default as sort } from './sort';

--- a/addon/array/reject-by.js
+++ b/addon/array/reject-by.js
@@ -1,0 +1,20 @@
+import createClassComputed from 'ember-macro-helpers/create-class-computed';
+import computed from 'ember-macro-helpers/computed';
+import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
+
+const defaultValue = [];
+
+export default createClassComputed(
+  [false, true, false],
+  (array, key, value) => {
+    return computed(normalizeArrayKey(array, [key]), value, (array, value) => {
+      if (!array) {
+        return defaultValue;
+      }
+      if (!key) {
+        return array;
+      }
+      return array.rejectBy(key, value);
+    });
+  }
+);

--- a/tests/acceptance/array-imports-test.js
+++ b/tests/acceptance/array-imports-test.js
@@ -23,6 +23,7 @@ import array, {
   map,
   objectAt,
   reduce,
+  rejectBy,
   reverse,
   slice,
   sort,
@@ -52,6 +53,7 @@ import _mapBy from 'ember-awesome-macros/array/map-by';
 import _map from 'ember-awesome-macros/array/map';
 import _objectAt from 'ember-awesome-macros/array/object-at';
 import _reduce from 'ember-awesome-macros/array/reduce';
+import _rejectBy from 'ember-awesome-macros/array/reject-by';
 import _reverse from 'ember-awesome-macros/array/reverse';
 import _slice from 'ember-awesome-macros/array/slice';
 import _sort from 'ember-awesome-macros/array/sort';
@@ -86,6 +88,7 @@ test('all array global imports', function(assert) {
   assert.ok(array.map);
   assert.ok(array.objectAt);
   assert.ok(array.reduce);
+  assert.ok(array.rejectBy);
   assert.ok(array.reverse);
   assert.ok(array.slice);
   assert.ok(array.sort);
@@ -119,6 +122,7 @@ test('all array imports', function(assert) {
   assert.ok(map);
   assert.ok(objectAt);
   assert.ok(reduce);
+  assert.ok(rejectBy);
   assert.ok(reverse);
   assert.ok(slice);
   assert.ok(sort);
@@ -152,6 +156,7 @@ test('all array default imports', function(assert) {
   assert.ok(_map);
   assert.ok(_objectAt);
   assert.ok(_reduce);
+  assert.ok(_rejectBy);
   assert.ok(_reverse);
   assert.ok(_slice);
   assert.ok(_sort);

--- a/tests/integration/array/reject-by-test.js
+++ b/tests/integration/array/reject-by-test.js
@@ -1,0 +1,111 @@
+import { rejectBy } from 'ember-awesome-macros/array';
+import { raw } from 'ember-awesome-macros';
+import EmberObject from 'ember-object';
+import { A as emberA } from 'ember-array/utils';
+import { module, test } from 'qunit';
+import compute from 'ember-macro-test-helpers/compute';
+
+module('Integration | Macro | array | reject by');
+
+test('it returns empty array if array undefined', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key', 'value'),
+    deepEqual: []
+  });
+});
+
+test('it returns the original array if key undefined', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key', 'value'),
+    properties: {
+      array: emberA([{ test: 'val1' }, { test: 'val2' }])
+    },
+    deepEqual: [{ test: 'val1' }, { test: 'val2' }]
+  });
+});
+
+test('it returns the original array if not found', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key', 'value'),
+    properties: {
+      array: emberA([{ test: 'val1' }, { test: 'val2' }]),
+      key: 'test',
+      value: 'val3'
+    },
+    deepEqual: [{ test: 'val1' }, { test: 'val2' }]
+  });
+});
+
+test('it filters array if found', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key', 'value'),
+    properties: {
+      array: emberA([{ test: 'val1' }, { test: 'val2' }]),
+      key: 'test',
+      value: 'val2'
+    },
+    deepEqual: [{ test: 'val1' }]
+  });
+});
+
+test('it responds to array property value changes', function(assert) {
+  let array = emberA([
+    EmberObject.create({ test1: 'val1', test2: 'val1' }),
+    EmberObject.create({ test1: 'val1', test2: 'val1' })
+  ]);
+
+  let { subject } = compute({
+    computed: rejectBy('array', 'key', 'value'),
+    properties: {
+      array,
+      key: 'test1',
+      value: 'val2'
+    }
+  });
+
+  assert.equal(subject.get('computed.length'), 2);
+
+  array.set('1.test1', 'val2');
+
+  assert.equal(subject.get('computed.length'), 1);
+
+  array.pushObject(EmberObject.create({ test1: 'val2', test2: 'val2' }));
+
+  assert.equal(subject.get('computed.length'), 1);
+
+  subject.set('key', 'test2');
+
+  assert.equal(subject.get('computed.length'), 2);
+
+  subject.set('value', 'val1');
+
+  assert.equal(subject.get('computed.length'), 1);
+});
+
+test('it handles raw numbers', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key', 3),
+    properties: {
+      array: emberA([{ test: 2 }, { test: 3 }]),
+      key: 'test'
+    },
+    deepEqual: [{ test: 2 }]
+  });
+});
+
+test('composable: it filters array if found', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy(
+      raw(emberA([{ test: 'val1' }, { test: 'val2' }])),
+      raw('test'),
+      raw('val2')
+    ),
+    deepEqual: [{ test: 'val1' }]
+  });
+});


### PR DESCRIPTION
I just had a case where `rejectBy` as opposed to `filterBy` would have been handy and was wondering why this wasn't included already…