### PR TITLE
Fix in documentation for `array.reduce`

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ value1: array.reduce(
     return obj;
   },
   // initial value is a factory function because we mutate the object
-  () => { return {}; }
+  () => ({})
 ), // { one: 0, two: 1 }
 
 string: 'one', 'two',

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ value1: array.reduce(
     return obj;
   },
   // initial value is a factory function because we mutate the object
-  () => {}
+  () => { return {}; }
 ), // { one: 0, two: 1 }
 
 string: 'one', 'two',


### PR DESCRIPTION
`() => {}` returns a function that returns `undefined` (as opposed to `() => []` that returns a function that returns an empty array). It should be `() => { return {}; }`.