### PR TITLE
[WIP] filterBy/rejectBy: third argument optional

### DIFF
--- a/tests/integration/array/filter-by-test.js
+++ b/tests/integration/array/filter-by-test.js
@@ -52,6 +52,18 @@ test('it filters array if found', function(assert) {
   });
 });
 
+test('it filters array by truthiness, if no third argument was given', function(assert) {
+  compute({
+    assert,
+    computed: filterBy('array', 'key'),
+    properties: {
+      array: emberA([{ test: false }, { test: 'val2' }]),
+      key: 'test'
+    },
+    deepEqual: [{ test: 'val2' }]
+  });
+});
+
 test('it responds to array property value changes', function(assert) {
   let array = emberA([
     EmberObject.create({ test1: 'val1', test2: 'val1' }),

--- a/tests/integration/array/reject-by-test.js
+++ b/tests/integration/array/reject-by-test.js
@@ -52,6 +52,18 @@ test('it filters array if found', function(assert) {
   });
 });
 
+test('it filters array by truthiness, if no third argument was given', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key'),
+    properties: {
+      array: emberA([{ test: false }, { test: 'val2' }]),
+      key: 'test'
+    },
+    deepEqual: [{ test: false }]
+  });
+});
+
 test('it responds to array property value changes', function(assert) {
   let array = emberA([
     EmberObject.create({ test1: 'val1', test2: 'val1' }),


### PR DESCRIPTION
My go at #362. So far I only added tests.

I won't be able to properly implement this without also submitting a PR to ember-awesome-macros, as `build-computed` (and all) appear to assume a fixed arity.

```js
const defaultValue = [];

export default createClassComputed(
  [false, true, false],
  (array, key, value) => {
    return computed(normalizeArrayKey(array, [key]), value, function(array, value) {
      console.log(arguments.length, typeof value); // => 2, "undefined"
      if (!array || !key) {
        return defaultValue;
      }
      return array.filterBy(key, value);
    });
  }
);
```