### PR TITLE
Add support for sorting moment objects

### DIFF
--- a/addon/array/sort.js
+++ b/addon/array/sort.js
@@ -4,6 +4,12 @@ import { normalizeArray } from './-utils';
 
 const { compare } = Ember;
 
+function getComparable(a, prop) {
+  const val = get(a, prop);
+
+  return val && val._isAMomentObject ? val.unix() : val;
+}
+
 export default function(array, sortDefinition) {
   let computedCallback;
 
@@ -24,7 +30,7 @@ export default function(array, sortDefinition) {
           for (let i = 0; i < sortDefinition.length; i++) {
             let key = sortDefinition[i];
             let [prop, direction] = key.split(':');
-            result = compare(get(a, prop), get(b, prop));
+            result = compare(getComparable(a, prop), getComparable(b, prop));
             if (result !== 0) {
               if (direction === 'desc') {
                 result *= -1;


### PR DESCRIPTION
Allow for the ability to sort moment.js objects using the `value2: array.sort('array2', ['key1', 'key2:desc'])` sort syntax.

In order to support that sort syntax, objects must be `Ember.Comparable` (moment.js objects are not).

No hard feelings if you're not interested in this, I extended your sort computed to do this for my project anyways so I figured I may as well open it to you and let you decide if you'd like it.

Backstory: I inherited a project that made heavy use of this syntax (with many dynamic `sortDefinitions`) but using `Ember.computed.sort`. We are also using `ember-cli-moment-shim` and in the past that addon was able to extend moment objects with `Ember.Comparable` but support was dropped in more recent versions (see: https://github.com/jasonmit/ember-cli-moment-shim/issues/97). Looking around for a solution I found your addon and was able to easily extend it.

Again, no hard feelings if you'd like to close this without merge but at the very least just wanted to say thanks for providing me with a good base and offer up what I came up in case you would be interested!