### PR TITLE
[BUGFIX] Pass all keys to normalizeArrayKey

### DIFF
--- a/addon/array/-utils.js
+++ b/addon/array/-utils.js
@@ -4,7 +4,7 @@ import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
 const sentinelValue = {};
 
 function normalizeArrayArgs(keys) {
-  keys[0] = normalizeArrayKey(keys[0]);
+  keys[0] = normalizeArrayKey(...keys);
 }
 
 export function normalizeArray({


### PR DESCRIPTION
Fixes `array.sort` dependent keys