### PR TITLE
Make array macros work with native JS arrays

### DIFF
--- a/addon/array/any.js
+++ b/addon/array/any.js
@@ -1,5 +1,6 @@
+import { A as emberA } from '@ember/array';
 import { normalizeArray } from './-utils';
 
 export default normalizeArray({ defaultValue: () => false }, (array, callback) => {
-  return array.any(callback);
+  return emberA(array).any(callback);
 });

--- a/addon/array/compact.js
+++ b/addon/array/compact.js
@@ -1,5 +1,6 @@
+import { A as emberA } from '@ember/array';
 import { normalizeArray } from './-utils';
 
 export default normalizeArray({}, array => {
-  return array.compact();
+  return emberA(array).compact();
 });

--- a/addon/array/filter-by.js
+++ b/addon/array/filter-by.js
@@ -1,3 +1,4 @@
+import { A as emberA } from '@ember/array';
 import createClassComputed from 'ember-macro-helpers/create-class-computed';
 import computed from 'ember-macro-helpers/computed';
 import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
@@ -13,7 +14,7 @@ export default createClassComputed(
       if (!array || !key) {
         return [];
       }
-      return array.filterBy(key, ...args);
+      return emberA(array).filterBy(key, ...args);
     });
   }
 );

--- a/addon/array/find-by.js
+++ b/addon/array/find-by.js
@@ -1,3 +1,4 @@
+import { A as emberA } from '@ember/array';
 import createClassComputed from 'ember-macro-helpers/create-class-computed';
 import computed from 'ember-macro-helpers/computed';
 import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
@@ -9,7 +10,7 @@ export default createClassComputed(
       if (!array || !key) {
         return undefined;
       }
-      return array.findBy(key, value);
+      return emberA(array).findBy(key, value);
     });
   }
 );

--- a/addon/array/is-any.js
+++ b/addon/array/is-any.js
@@ -1,3 +1,4 @@
+import { A as emberA } from '@ember/array';
 import createClassComputed from 'ember-macro-helpers/create-class-computed';
 import computed from 'ember-macro-helpers/computed';
 import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
@@ -11,7 +12,7 @@ export default createClassComputed(
     }
     return computed(...args, (array, ...args) => {
       if (array) {
-        return array.isAny(key, ...args);
+        return emberA(array).isAny(key, ...args);
       }
     });
   }

--- a/addon/array/is-every.js
+++ b/addon/array/is-every.js
@@ -1,3 +1,4 @@
+import { A as emberA } from '@ember/array';
 import createClassComputed from 'ember-macro-helpers/create-class-computed';
 import computed from 'ember-macro-helpers/computed';
 import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
@@ -11,7 +12,7 @@ export default createClassComputed(
     }
     return computed(...args, (array, ...args) => {
       if (array) {
-        return array.isEvery(key, ...args);
+        return emberA(array).isEvery(key, ...args);
       }
     });
   }

--- a/addon/array/map-by.js
+++ b/addon/array/map-by.js
@@ -1,3 +1,4 @@
+import { A as emberA } from '@ember/array';
 import createClassComputed from 'ember-macro-helpers/create-class-computed';
 import computed from 'ember-macro-helpers/computed';
 import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
@@ -9,7 +10,7 @@ export default createClassComputed(
       if (!array || !key) {
         return array;
       }
-      return array.mapBy(key);
+      return emberA(array).mapBy(key);
     });
   }
 );

--- a/addon/array/object-at.js
+++ b/addon/array/object-at.js
@@ -1,5 +1,6 @@
+import { A as emberA } from '@ember/array';
 import { normalizeArray } from './-utils';
 
 export default normalizeArray({}, (array, index) => {
-  return array.objectAt(index);
+  return emberA(array).objectAt(index);
 });

--- a/addon/array/reject-by.js
+++ b/addon/array/reject-by.js
@@ -1,3 +1,4 @@
+import { A as emberA } from '@ember/array';
 import createClassComputed from 'ember-macro-helpers/create-class-computed';
 import computed from 'ember-macro-helpers/computed';
 import normalizeArrayKey from 'ember-macro-helpers/normalize-array-key';
@@ -16,7 +17,7 @@ export default createClassComputed(
       if (!key) {
         return array;
       }
-      return array.rejectBy(key, ...args);
+      return emberA(array).rejectBy(key, ...args);
     });
   }
 );

--- a/addon/array/uniq-by.js
+++ b/addon/array/uniq-by.js
@@ -12,6 +12,7 @@ export default createClassComputed(
       if (array === undefined || key === undefined) {
         return array;
       }
+
       if (!array.uniqBy) {
         // TODO: polyfill this
         // from https://github.com/emberjs/ember.js/blob/v2.11.0/packages/ember-runtime/lib/mixins/enumerable.js#L1094-L1105
@@ -28,6 +29,7 @@ export default createClassComputed(
 
         return ret;
       }
+
       return array.uniqBy(key);
     });
   }

--- a/addon/array/uniq.js
+++ b/addon/array/uniq.js
@@ -1,5 +1,6 @@
+import { A as emberA } from '@ember/array';
 import { normalizeArray } from './-utils';
 
 export default normalizeArray({}, array => {
-  return array.uniq();
+  return emberA(array).uniq();
 });

--- a/addon/array/without.js
+++ b/addon/array/without.js
@@ -1,5 +1,6 @@
+import { A as emberA } from '@ember/array';
 import { normalizeArray } from './-utils';
 
 export default normalizeArray({}, (array, item) => {
-  return array.without(item);
+  return emberA(array).without(item);
 });

--- a/tests/integration/array/any-test.js
+++ b/tests/integration/array/any-test.js
@@ -87,3 +87,14 @@ test('composable: it returns true if any true', function(assert) {
     strictEqual: true
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: any('array', result => result === 3),
+    properties: {
+      array: [1, 2]
+    },
+    strictEqual: false
+  });
+});

--- a/tests/integration/array/compact-test.js
+++ b/tests/integration/array/compact-test.js
@@ -53,3 +53,14 @@ test('composable: it calls compact on array', function(assert) {
     deepEqual: [2]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: compact('array'),
+    properties: {
+      array: [undefined, 2]
+    },
+    deepEqual: [2]
+  });
+});

--- a/tests/integration/array/concat-test.js
+++ b/tests/integration/array/concat-test.js
@@ -77,3 +77,16 @@ test('composable: it calls concat on array', function(assert) {
     deepEqual: [0, value1, value2]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: concat('array', 'value1', 'value2'),
+    properties: {
+      array: [0],
+      value1,
+      value2
+    },
+    deepEqual: [0, value1, value2]
+  });
+});

--- a/tests/integration/array/every-test.js
+++ b/tests/integration/array/every-test.js
@@ -87,3 +87,14 @@ test('composable: it returns true if all true', function(assert) {
     strictEqual: true
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: every('array', result => result === 1),
+    properties: {
+      array: [1, 2]
+    },
+    strictEqual: false
+  });
+});

--- a/tests/integration/array/filter-by-test.js
+++ b/tests/integration/array/filter-by-test.js
@@ -145,3 +145,16 @@ test('composable: it filters array if found', function(assert) {
     deepEqual: [{ test: 'val2' }]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: filterBy('array', 'key', 'value'),
+    properties: {
+      array: [{ test: 'val1' }, { test: 'val2' }],
+      key: 'test',
+      value: 'val2'
+    },
+    deepEqual: [{ test: 'val2' }]
+  });
+});

--- a/tests/integration/array/filter-test.js
+++ b/tests/integration/array/filter-test.js
@@ -99,3 +99,14 @@ test('composable: it filters array if found', function(assert) {
     deepEqual: [2]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: filter('array', result => result === 2),
+    properties: {
+      array: [1, 2]
+    },
+    deepEqual: [2]
+  });
+});

--- a/tests/integration/array/find-by-test.js
+++ b/tests/integration/array/find-by-test.js
@@ -1,7 +1,6 @@
 import { findBy } from 'ember-awesome-macros/array';
 import { raw } from 'ember-awesome-macros';
 import EmberObject from '@ember/object';
-import { A as emberA } from '@ember/array';
 import { module, test } from 'qunit';
 import compute from 'ember-macro-test-helpers/compute';
 
@@ -20,7 +19,7 @@ test('it returns undefined if key undefined', function(assert) {
     assert,
     computed: findBy('array', 'key', 'value'),
     properties: {
-      array: emberA([{ test: 'val1' }, { test: 'val2' }])
+      array: [{ test: 'val1' }, { test: 'val2' }]
     },
     strictEqual: undefined
   });
@@ -31,7 +30,7 @@ test('it returns undefined if not found', function(assert) {
     assert,
     computed: findBy('array', 'key', 'value'),
     properties: {
-      array: emberA([{ test: 'val1' }, { test: 'val2' }]),
+      array: [{ test: 'val1' }, { test: 'val2' }],
       key: 'test',
       value: 'val3'
     },
@@ -45,7 +44,7 @@ test('it returns item if found', function(assert) {
     assert,
     computed: findBy('array', 'key', 'value'),
     properties: {
-      array: emberA([{ test: 'val1' }, expected]),
+      array: [{ test: 'val1' }, expected],
       key: 'test',
       value: 'val2'
     },
@@ -54,10 +53,10 @@ test('it returns item if found', function(assert) {
 });
 
 test('it responds to array property value changes', function(assert) {
-  let array = emberA([
+  let array = [
     EmberObject.create({ test1: 'val1', test2: 'val1' }),
     EmberObject.create({ test1: 'val2', test2: 'val2' })
-  ]);
+  ];
 
   let { subject } = compute({
     computed: findBy('array', 'key', 'value'),
@@ -96,7 +95,7 @@ test('it handles raw numbers', function(assert) {
     assert,
     computed: findBy('array', 'key', 3),
     properties: {
-      array: emberA([{ test: 2 }, expected]),
+      array: [{ test: 2 }, expected],
       key: 'test'
     },
     strictEqual: expected
@@ -108,7 +107,7 @@ test('composable: it returns item if found', function(assert) {
   compute({
     assert,
     computed: findBy(
-      raw(emberA([{ test: 'val1' }, expected])),
+      raw([{ test: 'val1' }, expected]),
       raw('test'),
       raw('val2')
     ),

--- a/tests/integration/array/find-by-test.js
+++ b/tests/integration/array/find-by-test.js
@@ -1,6 +1,7 @@
 import { findBy } from 'ember-awesome-macros/array';
 import { raw } from 'ember-awesome-macros';
 import EmberObject from '@ember/object';
+import { A as emberA } from '@ember/array';
 import { module, test } from 'qunit';
 import compute from 'ember-macro-test-helpers/compute';
 
@@ -19,7 +20,7 @@ test('it returns undefined if key undefined', function(assert) {
     assert,
     computed: findBy('array', 'key', 'value'),
     properties: {
-      array: [{ test: 'val1' }, { test: 'val2' }]
+      array: emberA([{ test: 'val1' }, { test: 'val2' }])
     },
     strictEqual: undefined
   });
@@ -30,7 +31,7 @@ test('it returns undefined if not found', function(assert) {
     assert,
     computed: findBy('array', 'key', 'value'),
     properties: {
-      array: [{ test: 'val1' }, { test: 'val2' }],
+      array: emberA([{ test: 'val1' }, { test: 'val2' }]),
       key: 'test',
       value: 'val3'
     },
@@ -44,7 +45,7 @@ test('it returns item if found', function(assert) {
     assert,
     computed: findBy('array', 'key', 'value'),
     properties: {
-      array: [{ test: 'val1' }, expected],
+      array: emberA([{ test: 'val1' }, expected]),
       key: 'test',
       value: 'val2'
     },
@@ -53,10 +54,10 @@ test('it returns item if found', function(assert) {
 });
 
 test('it responds to array property value changes', function(assert) {
-  let array = [
+  let array = emberA([
     EmberObject.create({ test1: 'val1', test2: 'val1' }),
     EmberObject.create({ test1: 'val2', test2: 'val2' })
-  ];
+  ]);
 
   let { subject } = compute({
     computed: findBy('array', 'key', 'value'),
@@ -95,7 +96,7 @@ test('it handles raw numbers', function(assert) {
     assert,
     computed: findBy('array', 'key', 3),
     properties: {
-      array: [{ test: 2 }, expected],
+      array: emberA([{ test: 2 }, expected]),
       key: 'test'
     },
     strictEqual: expected
@@ -107,10 +108,24 @@ test('composable: it returns item if found', function(assert) {
   compute({
     assert,
     computed: findBy(
-      raw([{ test: 'val1' }, expected]),
+      raw(emberA([{ test: 'val1' }, expected])),
       raw('test'),
       raw('val2')
     ),
+    strictEqual: expected
+  });
+});
+
+test('it handles native arrays', function(assert) {
+  let expected = { test: 'val2' };
+  compute({
+    assert,
+    computed: findBy('array', 'key', 'value'),
+    properties: {
+      array: [{ test: 'val1' }, expected],
+      key: 'test',
+      value: 'val2'
+    },
     strictEqual: expected
   });
 });

--- a/tests/integration/array/find-test.js
+++ b/tests/integration/array/find-test.js
@@ -89,3 +89,14 @@ test('composable: it returns item if found', function(assert) {
     strictEqual: 2
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: find('array', result => result === 2),
+    properties: {
+      array: [1, 2]
+    },
+    strictEqual: 2
+  });
+});

--- a/tests/integration/array/first-test.js
+++ b/tests/integration/array/first-test.js
@@ -35,3 +35,14 @@ test('handles array changes', function(assert) {
 
   assert.strictEqual(get(subject, 'computed'), 'test2');
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: first('array'),
+    properties: {
+      array: ['test1', 'test2']
+    },
+    strictEqual: 'test1'
+  });
+});

--- a/tests/integration/array/group-by-test.js
+++ b/tests/integration/array/group-by-test.js
@@ -193,3 +193,30 @@ test('it groups array by key and comparator', function(assert) {
 
   assert.deepEqual(subject.get('computed'), expected);
 });
+
+test('it handles native arrays', function(assert) {
+  let item1 = { test: 1, name: 'foo' };
+  let item2 = { test: 2, name: 'bar' };
+  let item3 = { test: 3, name: 'foo' };
+
+  compute({
+    assert,
+    computed: groupBy('array', 'key'),
+    properties: {
+      array: [item1, item2, item3],
+      key: 'name'
+    },
+    deepEqual: [
+      {
+        key: 'name',
+        value: 'foo',
+        items: [item1, item3]
+      },
+      {
+        key: 'name',
+        value: 'bar',
+        items: [item2]
+      }
+    ]
+  });
+});

--- a/tests/integration/array/includes-test.js
+++ b/tests/integration/array/includes-test.js
@@ -80,3 +80,15 @@ test('it handles nesting', function(assert) {
     strictEqual: true
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: includes('array', 'source'),
+    properties: {
+      array: ['my value'],
+      source: 'my value'
+    },
+    strictEqual: true
+  });
+});

--- a/tests/integration/array/index-of-test.js
+++ b/tests/integration/array/index-of-test.js
@@ -64,3 +64,16 @@ test('composable: it calls indexOf on array', function(assert) {
     strictEqual: 2
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: indexOf('array', 'value', 'fromIndex'),
+    properties: {
+      array: [1, 2, 1],
+      value: 1,
+      fromIndex: 1
+    },
+    strictEqual: 2
+  });
+});

--- a/tests/integration/array/invoke-test.js
+++ b/tests/integration/array/invoke-test.js
@@ -95,3 +95,21 @@ test('it responds to array property value changes', function(assert) {
     'foo1-baz-val2'
   ]);
 });
+
+test('it handles native arrays', function(assert) {
+  array = [{
+    foo(arg = 'bar') {
+      return arg + '-eval';
+    }
+  }];
+
+  compute({
+    assert,
+    computed: invoke('array', 'methodName'),
+    properties: {
+      array,
+      methodName: 'foo'
+    },
+    deepEqual: ['bar-eval']
+  });
+});

--- a/tests/integration/array/is-any-test.js
+++ b/tests/integration/array/is-any-test.js
@@ -177,3 +177,16 @@ test('composable: it calls isAny on array', function(assert) {
     strictEqual: true
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: isAny('array', 'key', 'value'),
+    properties: {
+      array: [{ test: 'val1' }, { test: 'val2' }],
+      key: 'test',
+      value: 'val2'
+    },
+    strictEqual: true
+  });
+});

--- a/tests/integration/array/is-every-test.js
+++ b/tests/integration/array/is-every-test.js
@@ -181,3 +181,16 @@ test('composable: it calls isEvery on array', function(assert) {
     strictEqual: true
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: isEvery('array', 'key', 'value'),
+    properties: {
+      array: [{ test: 'val1' }, { test: 'val1' }],
+      key: 'test',
+      value: 'val1'
+    },
+    strictEqual: true
+  });
+});

--- a/tests/integration/array/join-test.js
+++ b/tests/integration/array/join-test.js
@@ -111,3 +111,15 @@ test('doesn\'t calculate when unnecessary', function(assert) {
 
   assert.notOk(callback.called);
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: join('array', 'separator'),
+    properties: {
+      array: ['test1', 'test2'],
+      separator
+    },
+    strictEqual: 'test1, test2'
+  });
+});

--- a/tests/integration/array/last-index-of-test.js
+++ b/tests/integration/array/last-index-of-test.js
@@ -64,3 +64,16 @@ test('composable: it calls lastIndexOf on array', function(assert) {
     strictEqual: 0
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: lastIndexOf('array', 'value', 'fromIndex'),
+    properties: {
+      array: [1, 2, 1],
+      value: 1,
+      fromIndex: 1
+    },
+    strictEqual: 0
+  });
+});

--- a/tests/integration/array/last-test.js
+++ b/tests/integration/array/last-test.js
@@ -35,3 +35,14 @@ test('handles array changes', function(assert) {
 
   assert.strictEqual(get(subject, 'computed'), 'test1');
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: last('array'),
+    properties: {
+      array: ['test1', 'test2']
+    },
+    strictEqual: 'test2'
+  });
+});

--- a/tests/integration/array/length-test.js
+++ b/tests/integration/array/length-test.js
@@ -51,3 +51,14 @@ test('composable: it gets length on array', function(assert) {
     strictEqual: 3
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: length('array'),
+    properties: {
+      array: [0, 0, 0]
+    },
+    strictEqual: 3
+  });
+});

--- a/tests/integration/array/map-by-test.js
+++ b/tests/integration/array/map-by-test.js
@@ -77,3 +77,15 @@ test('composable: it maps array by key', function(assert) {
     deepEqual: [1, 2]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: mapBy('array', 'key'),
+    properties: {
+      array: [{ test: 1 }, { test: 2 }],
+      key: 'test'
+    },
+    deepEqual: [1, 2]
+  });
+});

--- a/tests/integration/array/map-test.js
+++ b/tests/integration/array/map-test.js
@@ -76,3 +76,14 @@ test('composable: it maps array', function(assert) {
     deepEqual: [1, 2]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: map('array', item => item.test),
+    properties: {
+      array: [{ test: 1 }, { test: 2 }]
+    },
+    deepEqual: [1, 2]
+  });
+});

--- a/tests/integration/array/object-at-test.js
+++ b/tests/integration/array/object-at-test.js
@@ -83,3 +83,15 @@ test('doesn\'t calculate when unnecessary', function(assert) {
 
   assert.notOk(callback.called);
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: objectAt('array', 'source'),
+    properties: {
+      array: ['my value'],
+      source: 0
+    },
+    strictEqual: 'my value'
+  });
+});

--- a/tests/integration/array/reduce-test.js
+++ b/tests/integration/array/reduce-test.js
@@ -176,3 +176,18 @@ test('composable: it calls reduce on array', function(assert) {
     strictEqual: 6
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: reduce('array', 'callback', 'initialValue'),
+    properties: {
+      array: [1, 2],
+      callback(accumulator, currentValue) {
+        return accumulator + currentValue;
+      },
+      initialValue: 3
+    },
+    strictEqual: 6
+  });
+});

--- a/tests/integration/array/reject-by-test.js
+++ b/tests/integration/array/reject-by-test.js
@@ -145,3 +145,16 @@ test('composable: it filters array if found', function(assert) {
     deepEqual: [{ test: 'val1' }]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: rejectBy('array', 'key', 'value'),
+    properties: {
+      array: [{ test: 'val1' }, { test: 'val2' }],
+      key: 'test',
+      value: 'val2'
+    },
+    deepEqual: [{ test: 'val1' }]
+  });
+});

--- a/tests/integration/array/reverse-test.js
+++ b/tests/integration/array/reverse-test.js
@@ -64,3 +64,14 @@ test('composable: it calls reverse on array', function(assert) {
     deepEqual: [2, 1]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: reverse('array'),
+    properties: {
+      array: [1, 2]
+    },
+    deepEqual: [2, 1]
+  });
+});

--- a/tests/integration/array/slice-test.js
+++ b/tests/integration/array/slice-test.js
@@ -64,3 +64,16 @@ test('composable: it calls slice on array', function(assert) {
     deepEqual: [2, 1]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: slice('array', 'begin', 'end'),
+    properties: {
+      array: [1, 2, 1, 2],
+      begin: 1,
+      end: 3
+    },
+    deepEqual: [2, 1]
+  });
+});

--- a/tests/integration/array/sort-test.js
+++ b/tests/integration/array/sort-test.js
@@ -241,3 +241,14 @@ test('composable: it returns a sorted array', function(assert) {
     deepEqual: [1, 2, 3]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: sort('array'),
+    properties: {
+      array: ['xyz', 'abc']
+    },
+    deepEqual: ['abc', 'xyz']
+  });
+});

--- a/tests/integration/array/uniq-by-test.js
+++ b/tests/integration/array/uniq-by-test.js
@@ -77,3 +77,15 @@ test('composable: it returns unique objects by key', function(assert) {
     deepEqual: [{ test: 1 }]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: uniqBy('array', 'key'),
+    properties: {
+      array: [{ test: 1 }, { test: 1 }],
+      key: 'test'
+    },
+    deepEqual: [{ test: 1 }]
+  });
+});

--- a/tests/integration/array/uniq-test.js
+++ b/tests/integration/array/uniq-test.js
@@ -76,3 +76,14 @@ test('composable: it calls uniq on array', function(assert) {
     deepEqual: [1]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: uniq('array'),
+    properties: {
+      array: [1, 1]
+    },
+    deepEqual: [1]
+  });
+});

--- a/tests/integration/array/without-test.js
+++ b/tests/integration/array/without-test.js
@@ -62,3 +62,15 @@ test('composable: it calls without on array', function(assert) {
     deepEqual: [2, 2]
   });
 });
+
+test('it handles native arrays', function(assert) {
+  compute({
+    assert,
+    computed: without('array', 'item'),
+    properties: {
+      array: [1, 2, 1, 2],
+      item: 1
+    },
+    deepEqual: [2, 2]
+  });
+});


### PR DESCRIPTION
The array macros (or most of them) assumed the source arrays to be `Ember.Array`s which I don't think is necessary (and breaks without prototype extensions, e.g. in FastBoot).

Although CPs won't update correctly when defined on native JS arrays there's no reason why they should not compute correctly initially (and that's also what Ember's own array CP macros do).