### PR TITLE
failing test for ember 2.17.0 double render

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "ember-cli-dependency-checker": "^2.0.0",
     "ember-cli-eslint": "^4.2.1",
     "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^4.1.1",
     "ember-cli-shims": "^1.2.0",

--- a/tests/integration/array/reject-by-test.js
+++ b/tests/integration/array/reject-by-test.js
@@ -1,8 +1,11 @@
-import { rejectBy } from 'ember-awesome-macros/array';
-import { raw } from 'ember-awesome-macros';
 import { A as emberA } from '@ember/array';
+import { filterBy, rejectBy } from 'ember-awesome-macros/array';
 import { module, test } from 'qunit';
+import { raw } from 'ember-awesome-macros';
+import { setupRenderingTest } from 'ember-qunit';
+import Component from '@ember/component';
 import compute from 'ember-macro-test-helpers/compute';
+import hbs from 'htmlbars-inline-precompile';
 
 module('Integration | Macro | array | reject by');
 
@@ -103,5 +106,32 @@ test('it handles native arrays', function(assert) {
       value: 'val2'
     },
     deepEqual: [{ test: 'val1' }]
+  });
+});
+
+module('Rendering Integration | Macro | array | reject by', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it composes with filter-by', function(assert) {
+    this.owner.register('component:my-component', Component.extend({
+      key: 'test',
+      value: 'val2',
+      computed: rejectBy(filterBy('array', raw('isFun'), true), 'key', 'value')
+    }));
+
+    this.owner.register('template:components/my-component', hbs`
+      {{#each computed as |item|}}
+        {{item.test}}
+      {{/each}}
+    `);
+
+    this.array = [];
+
+    return this.render(hbs`{{my-component array=array}}`)
+      .then(() => {
+        this.set('array', [{ test: 'val1', isFun: true }, { test: 'val2', isFun: true }, { test: 'val3', isFun: false }]);
+
+        assert.equal(this.$().text().trim(), 'val1');
+      });
   });
 });


### PR DESCRIPTION
First, thanks for the great addon and all the work you do in the Ember community!

This is a failing test for a double render we ran into while chaining array.rejectBy and array.filterBy while using ember 2.17.0.

The test passes just fine on 2.16.X.

I also imagine there's a better place to put this integration test that actually does a render rather than mixing it in the same file with the other integration tests.

Of potential note:
- the order in which the computed are combined does not seem to matter
- they both compose fine with sort, just not each other

Do you think this should instead be filed as an ember 2.17 regression?