### PR TITLE
add bool macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 
 ##### Boolean
 * [`and`](#and)
+* [`bool`](#bool)
 * [`conditional`](#conditional)
 * [`defaultTrue`](#defaulttrue)
 * [`not`](#not)
@@ -542,6 +543,18 @@ wraps [`Ember.Enumerable.without`](http://emberjs.com/api/classes/Ember.Enumerab
 array: Ember.A([1, 2, 3]),
 value1: array.without('array', 2), // [1, 3]
 value2: array.without('array', array.objectAt(1)) // [1, 3]
+```
+
+##### `bool`
+alias for [`and`](#and) but more explicit when using only one parameter
+
+```js
+source1: false,
+source2: true,
+source3: false,
+value1: bool('source1'), // false
+value2: bool('source2'), // true
+value3: bool('source3'), // false
 ```
 
 ##### `collect`

--- a/addon/bool.js
+++ b/addon/bool.js
@@ -1,0 +1,1 @@
+export { default } from './and';

--- a/addon/index.js
+++ b/addon/index.js
@@ -2,6 +2,7 @@ export { default as add } from './add';
 export { default as and } from './and';
 import array from './array';
 export { array };
+export { default as bool } from './bool';
 export { default as collect } from './collect';
 export { default as computed } from './computed';
 export { default as conditional } from './conditional';


### PR DESCRIPTION
I though it would be a good idea to add an alias called bool.
I felt weird writting:
```
and('source1')
```
...instead of...
```
bool('source1')
```