### PR TITLE
Add isEmpty macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 ##### Object
 * [`getBy`](#getby)
 * [`hash`](#hash)
+* [`isEmpty`](#isempty)
 * [`toStr`](#tostr)
 * [`toString`](#tostring)
 * [`typeOf`](#typeof)
@@ -709,6 +710,33 @@ value2: hash('source1', 'source2'), // { source1: 'my value 1', source2: 'my val
 
 // or you can mix and match, the result will be merged
 value3: hash('source1', { prop2: 'source2' }) // { source1: 'my value 1', prop2: 'my value 2' }
+```
+
+##### `isEmpty`
+wraps [`Ember.isEmpty`](https://emberjs.com/api/ember/3.0/functions/@ember%2Futils/isEmpty)
+
+```js
+sourceString1: '',
+sourceString2: foobar,
+
+sourceArray1: [],
+sourceArray2: [1, 2, 3],
+
+sourceObject1: {},
+sourceObject2: { size: 0 },
+
+valueString1: isEmpty('sourceString1'), // true
+valueString2: isEmpty('sourceString2'), // false
+
+valueArray1: isEmpty('sourceArray1'), // true
+valueArray2: isEmpty('sourceArray2'), // false
+
+valueObject1: isEmpty('sourceObject1'), // false
+valueObject2: isEmpty('sourceObject2'), // true
+
+valueObject1: isEmpty(collect(1, 2)), // false
+
+valueObject1: isEmpty([]), // true
 ```
 
 ##### `instanceOf`

--- a/README.md
+++ b/README.md
@@ -713,7 +713,7 @@ value3: hash('source1', { prop2: 'source2' }) // { source1: 'my value 1', prop2:
 ```
 
 ##### `isEmpty`
-wraps [`Ember.isEmpty`](https://emberjs.com/api/ember/3.0/functions/@ember%2Futils/isEmpty)
+wraps [`Ember.isEmpty`](https://emberjs.com/api/ember/release/functions/@ember%2Futils/isEmpty)
 
 ```js
 sourceString1: '',

--- a/addon/index.js
+++ b/addon/index.js
@@ -16,6 +16,7 @@ export { default as gte } from './gte';
 export { default as hash } from './hash';
 export { default as htmlSafe } from './html-safe';
 export { default as instanceOf } from './instance-of';
+export { default as isEmpty } from './is-empty';
 export { default as isHtmlSafe } from './is-html-safe';
 export { default as lt } from './lt';
 export { default as lte } from './lte';

--- a/addon/is-empty.js
+++ b/addon/is-empty.js
@@ -1,0 +1,20 @@
+import { isEmpty, typeOf } from '@ember/utils';
+import { isArray } from '@ember/array';
+import lazyComputed from 'ember-macro-helpers/lazy-computed';
+
+export default function(key) {
+  if (key === undefined || key === null) {
+    return true;
+  }
+  if (isArray(key)) {
+    return isEmpty(key);
+  }
+  if (typeOf(key) === 'string') {
+    return lazyComputed(key, `${key}.{length,size}`, (get, key) => {
+      return isEmpty(get(key));
+    });
+  }
+  return lazyComputed(key, (get, key) => {
+    return isEmpty(get(key));
+  });
+}

--- a/tests/acceptance/top-level-imports-test.js
+++ b/tests/acceptance/top-level-imports-test.js
@@ -19,6 +19,7 @@ import macros, {
   htmlSafe,
   instanceOf,
   isHtmlSafe,
+  isEmpty,
   lt,
   lte,
   math,
@@ -108,6 +109,7 @@ import _hash from 'ember-awesome-macros/hash';
 import _htmlSafe from 'ember-awesome-macros/html-safe';
 import _instanceOf from 'ember-awesome-macros/instance-of';
 import _isHtmlSafe from 'ember-awesome-macros/is-html-safe';
+import _isEmpty from 'ember-awesome-macros/is-empty';
 import _lt from 'ember-awesome-macros/lt';
 import _lte from 'ember-awesome-macros/lte';
 import _mod from 'ember-awesome-macros/mod';
@@ -153,6 +155,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(macros.htmlSafe);
     assert.ok(macros.instanceOf);
     assert.ok(macros.isHtmlSafe);
+    assert.ok(macros.isEmpty);
     assert.ok(macros.lt);
     assert.ok(macros.lte);
     assert.ok(macros.math);
@@ -247,6 +250,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(htmlSafe);
     assert.ok(instanceOf);
     assert.ok(isHtmlSafe);
+    assert.ok(isEmpty);
     assert.ok(lt);
     assert.ok(lte);
     assert.ok(math);
@@ -340,6 +344,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(_htmlSafe);
     assert.ok(_instanceOf);
     assert.ok(_isHtmlSafe);
+    assert.ok(_isEmpty);
     assert.ok(_lt);
     assert.ok(_lte);
     assert.ok(_mod);

--- a/tests/integration/is-empty-test.js
+++ b/tests/integration/is-empty-test.js
@@ -1,0 +1,148 @@
+import { collect, raw } from 'ember-awesome-macros';
+import { isEmpty } from 'ember-awesome-macros';
+import { module, test } from 'qunit';
+import { A as emberA } from '@ember/array';
+import compute from 'ember-macro-test-helpers/compute';
+
+module('Integration | Macro | isEmpty');
+
+test('empty without params', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty(),
+    properties: {},
+    strictEqual: true
+  });
+});
+
+test('empty with null', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: null
+    },
+    strictEqual: true
+  });
+});
+
+test('empty with undefined', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: undefined
+    },
+    strictEqual: true
+  });
+});
+
+test('empty with empty string', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: ''
+    },
+    strictEqual: true
+  });
+});
+
+test('empty with empty array', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: []
+    },
+    strictEqual: true
+  });
+});
+
+test('empty with native empty array', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty([]),
+    strictEqual: true
+  });
+});
+
+test('not empty with native array', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty([1, 2]),
+    strictEqual: false
+  });
+});
+
+test('composing: empty with raw empty array', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty(raw([])),
+    strictEqual: true
+  });
+});
+
+test('composing: it check if macro result is empty', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty(collect(1, 2)),
+    strictEqual: false
+  });
+});
+
+test('composing: it check if macro result is not empty', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty(collect()),
+    strictEqual: true
+  });
+});
+
+test('not empty with empty object', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: {}
+    },
+    strictEqual: false
+  });
+});
+
+test('not empty with string', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: 'Adam Hawkins'
+    },
+    strictEqual: false
+  });
+});
+
+test('not empty with array', function(assert) {
+  compute({
+    assert,
+    computed: isEmpty('source'),
+    properties: {
+      source: [0, 1, 2]
+    },
+    strictEqual: false
+  });
+});
+
+test('it responds to changes', function(assert) {
+  let array = emberA([]);
+
+  let { subject } = compute({
+    computed: isEmpty('array'),
+    properties: {
+      array
+    }
+  });
+
+  array.pushObject(2);
+
+  assert.strictEqual(subject.get('computed'), false);
+});


### PR DESCRIPTION
This PR add an global `isEmpty` which is a wrapper for `Ember.isEmpty`.
I'm not sure to doing it the right way and also about the doc in the readme.