### PR TITLE
Remove deprecation for helpers re-exported from ember-macro-helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,19 @@ value3: equal('source1', raw('my value')) // true
 value4: equal('source2', sum(1, 1)) // true
 ```
 
-Two essential primitive macros come from a different addon: [ember-macro-helpers](https://github.com/kellyselden/ember-macro-helpers)
+Three essential primitive macros are re-exported from a different addon: [ember-macro-helpers](https://github.com/kellyselden/ember-macro-helpers)
 
-* [raw](https://github.com/kellyselden/ember-macro-helpers#raw) makes composing macros easier
+* [computed](https://github.com/kellyselden/ember-macro-helpers#computed) makes composing macros easier
+* [raw](https://github.com/kellyselden/ember-macro-helpers#raw) allows you to escape string literals to be used in macros
 * [writable](https://github.com/kellyselden/ember-macro-helpers#writable) makes setting macros possible
+
+```js
+import computed from 'ember-awesome-macros/computed';
+import raw from 'ember-awesome-macros/raw';
+import writable from 'ember-awesome-macros/writable';
+// or
+import { computed, raw, writable } from 'ember-awesome-macros';
+```
 
 The API is not final until 1.0. I will be adding aliases as I think of better names for things, and possibly breaking or removing existing macros.
 

--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,5 +1,3 @@
-import { deprecate } from './-utils';
-
 import computed from 'ember-macro-helpers/computed';
 
-export default deprecate(computed, 'computed', 'ember-macro-helpers/computed');
+export default computed;

--- a/addon/computed.js
+++ b/addon/computed.js
@@ -1,3 +1,1 @@
-import computed from 'ember-macro-helpers/computed';
-
-export default computed;
+export { default } from 'ember-macro-helpers/computed';

--- a/addon/raw.js
+++ b/addon/raw.js
@@ -1,3 +1,1 @@
-import raw from 'ember-macro-helpers/raw';
-
-export default raw;
+export { default } from 'ember-macro-helpers/raw';

--- a/addon/raw.js
+++ b/addon/raw.js
@@ -1,5 +1,3 @@
-import { deprecate } from './-utils';
-
 import raw from 'ember-macro-helpers/raw';
 
-export default deprecate(raw, 'raw', 'ember-macro-helpers/raw');
+export default raw;

--- a/addon/writable.js
+++ b/addon/writable.js
@@ -1,3 +1,1 @@
-import writable from 'ember-macro-helpers/writable';
-
-export default writable;
+export { default } from 'ember-macro-helpers/writable';

--- a/addon/writable.js
+++ b/addon/writable.js
@@ -1,5 +1,3 @@
-import { deprecate } from './-utils';
-
 import writable from 'ember-macro-helpers/writable';
 
-export default deprecate(writable, 'writable', 'ember-macro-helpers/writable');
+export default writable;


### PR DESCRIPTION
Removes deprecations for `computed`, `raw` and `writable`.

Closes #264 