### PR TITLE
 array: Use `.slice()` to ensure plain arrays are not mutated to Ember arrays

### DIFF
--- a/addon/array/-utils.js
+++ b/addon/array/-utils.js
@@ -18,7 +18,9 @@ function convertArray(array) {
   }
 
   if (Array.isArray(array)) {
-    return emberA(array);
+    // we use .slice() here so that plain arrays are
+    // not internally mutated to Ember arrays
+    return emberA(array.slice());
   }
 
   if (isEmberArray(array)) {

--- a/tests/integration/array/first-test.js
+++ b/tests/integration/array/first-test.js
@@ -45,4 +45,20 @@ module('Integration | Macro | array | first', function(hooks) {
       strictEqual: 'test1'
     });
   });
+
+  test('it does not mutate native arrays to Ember arrays', function(assert) {
+    let { subject } = compute({
+      computed: first('array'),
+      properties: {
+        array: ['test1', 'test2']
+      }
+    });
+
+    // read `computed` property to make sure the array code has run
+    assert.ok(subject.get('computed'));
+
+    // read the array and make sure it has not been mutated
+    let array = subject.get('array');
+    assert.notOk(array.objectAt);
+  });
 });

--- a/tests/unit/array/utils/normalize-array-2-test.js
+++ b/tests/unit/array/utils/normalize-array-2-test.js
@@ -16,29 +16,35 @@ const secondParam = 'second param test';
 const returnValue = 'return value test';
 
 let funcStub;
-let array;
+let originalArray;
+let slicedArray;
 let macro;
+
+function initArray(array) {
+  originalArray = array;
+  sinon.stub(array, 'slice').returns(slicedArray);
+}
 
 module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
   hooks.beforeEach(function() {
-    array = emberA([]);
-    sinon.stub(array, 'slice').returns(array);
+    slicedArray = emberA([]);
+    initArray(emberA([]));
 
-    funcStub = sinon.stub(array, 'pop').returns(returnValue);
+    funcStub = sinon.stub(slicedArray, 'pop').returns(returnValue);
 
     macro = normalizeArray2('pop');
   });
 
   test('it returns array identity if array not array type and no default value', function(assert) {
-    array = {};
+    originalArray = {};
 
     compute({
       assert,
       computed: macro('array'),
       properties: {
-        array
+        array: originalArray
       },
-      strictEqual: array
+      strictEqual: originalArray
     });
   });
 
@@ -46,13 +52,13 @@ module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
     let { result } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
     });
 
-    assert.strictEqual(funcStub.thisValues[0], array);
+    assert.strictEqual(funcStub.thisValues[0], slicedArray);
     assert.deepEqual(funcStub.args, [[firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });
@@ -85,7 +91,7 @@ module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
 
   test('it calls func on ember data arrays', function(assert) {
     let arrayPromise = ArrayPromiseProxy.create({
-      promise: resolve(array)
+      promise: resolve(originalArray)
     });
 
     funcStub = sinon.stub(arrayPromise, 'isEvery').returns(returnValue);
@@ -144,21 +150,18 @@ module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
   });
 
   test('it handles native arrays', function(assert) {
-    array = [];
-    sinon.stub(array, 'slice').returns(array);
-
-    funcStub = sinon.stub(array, 'pop').returns(returnValue);
+    initArray([]);
 
     let { result } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
     });
 
-    assert.strictEqual(funcStub.thisValues[0], array);
+    assert.strictEqual(funcStub.thisValues[0], slicedArray);
     assert.deepEqual(funcStub.args, [[firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });
@@ -166,13 +169,13 @@ module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
   test('composable: it calls func on array', function(assert) {
     let { result } = compute({
       computed: macro(
-        raw(array),
+        raw(originalArray),
         raw(firstParam),
         raw(secondParam)
       )
     });
 
-    assert.strictEqual(funcStub.thisValues[0], array);
+    assert.strictEqual(funcStub.thisValues[0], slicedArray);
     assert.deepEqual(funcStub.args, [[firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });

--- a/tests/unit/array/utils/normalize-array-2-test.js
+++ b/tests/unit/array/utils/normalize-array-2-test.js
@@ -22,6 +22,8 @@ let macro;
 module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
   hooks.beforeEach(function() {
     array = emberA([]);
+    sinon.stub(array, 'slice').returns(array);
+
     funcStub = sinon.stub(array, 'pop').returns(returnValue);
 
     macro = normalizeArray2('pop');
@@ -143,6 +145,8 @@ module('Unit | Macro | array | utils | normalize array 2', function(hooks) {
 
   test('it handles native arrays', function(assert) {
     array = [];
+    sinon.stub(array, 'slice').returns(array);
+
     funcStub = sinon.stub(array, 'pop').returns(returnValue);
 
     let { result } = compute({

--- a/tests/unit/array/utils/normalize-array-3-test.js
+++ b/tests/unit/array/utils/normalize-array-3-test.js
@@ -16,18 +16,24 @@ const secondParam = 'second param test';
 const returnValue = 'return value test';
 
 let funcStub;
-let array;
+let originalArray;
+let slicedArray;
 let macro;
+
+function initArray(array) {
+  originalArray = array;
+  sinon.stub(array, 'slice').returns(slicedArray);
+}
 
 module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
   hooks.beforeEach(function() {
-    array = emberA([]);
-    sinon.stub(array, 'slice').returns(array);
+    slicedArray = emberA([]);
+    initArray(emberA([]));
 
     let obj = EmberObject.create({});
     obj[firstParam] = 1;
-    array.push(obj);
-    funcStub = sinon.stub(array, 'pop').returns(returnValue);
+    originalArray.push(obj);
+    funcStub = sinon.stub(slicedArray, 'pop').returns(returnValue);
 
     macro = normalizeArray3({
       func: 'pop'
@@ -35,15 +41,15 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
   });
 
   test('it returns array identity if array not array type and no default value', function(assert) {
-    array = {};
+    originalArray = {};
 
     compute({
       assert,
       computed: macro('array'),
       properties: {
-        array
+        array: originalArray
       },
-      strictEqual: array
+      strictEqual: originalArray
     });
   });
 
@@ -52,10 +58,10 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
       assert,
       computed: macro('array', 'key'),
       properties: {
-        array,
+        array: originalArray,
         key: true
       },
-      strictEqual: array
+      strictEqual: originalArray
     });
   });
 
@@ -63,13 +69,13 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { result } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
     });
 
-    assert.strictEqual(funcStub.thisValues[0], array);
+    assert.strictEqual(funcStub.thisValues[0], slicedArray);
     assert.deepEqual(funcStub.args, [[firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });
@@ -93,7 +99,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
 
   test('it calls func on ember data arrays', function(assert) {
     let arrayPromise = ArrayPromiseProxy.create({
-      promise: resolve(array)
+      promise: resolve(originalArray)
     });
 
     funcStub = sinon.stub(arrayPromise, 'isEvery').returns(returnValue);
@@ -125,13 +131,13 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { result } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
     });
 
-    assert.deepEqual(stub.args, [[array, firstParam, secondParam]]);
+    assert.deepEqual(stub.args, [[slicedArray, firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });
 
@@ -158,7 +164,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
       assert,
       computed: macro('array'),
       properties: {
-        array
+        array: originalArray
       },
       strictEqual: 1
     });
@@ -190,7 +196,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { subject } = compute({
       computed: macro('array', 'key'),
       properties: {
-        array
+        array: originalArray
       }
     });
 
@@ -205,7 +211,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     compute({
       computed: macro('array', 'firstParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam
       }
     });
@@ -217,7 +223,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     compute({
       computed: macro('array', 'firstParam', false),
       properties: {
-        array,
+        array: originalArray,
         firstParam
       }
     });
@@ -242,18 +248,17 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { subject } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
     });
 
-    array = [];
-    sinon.stub(array, 'slice').returns(array);
+    initArray([]);
 
-    funcStub = sinon.stub(array, 'pop').returns(returnValue);
+    subject.set('array', originalArray);
 
-    subject.set('array', array);
+    funcStub.resetHistory();
 
     subject.get('computed');
 
@@ -264,7 +269,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { subject } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
@@ -272,7 +277,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
 
     funcStub.reset();
 
-    array.pushObject({});
+    originalArray.pushObject({});
 
     subject.get('computed');
 
@@ -283,7 +288,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { subject } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
@@ -302,7 +307,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { subject } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
@@ -321,7 +326,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     let { subject } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
@@ -329,7 +334,7 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
 
     funcStub.reset();
 
-    array.set(`0.${firstParam}`, 2);
+    originalArray.set(`0.${firstParam}`, 2);
 
     subject.get('computed');
 
@@ -337,21 +342,18 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
   });
 
   test('it handles native arrays', function(assert) {
-    array = [];
-    sinon.stub(array, 'slice').returns(array);
-
-    funcStub = sinon.stub(array, 'pop').returns(returnValue);
+    initArray([]);
 
     let { result } = compute({
       computed: macro('array', 'firstParam', 'secondParam'),
       properties: {
-        array,
+        array: originalArray,
         firstParam,
         secondParam
       }
     });
 
-    assert.strictEqual(funcStub.thisValues[0], array);
+    assert.strictEqual(funcStub.thisValues[0], slicedArray);
     assert.deepEqual(funcStub.args, [[firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });
@@ -359,13 +361,13 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
   test('composable: it calls func on array', function(assert) {
     let { result } = compute({
       computed: macro(
-        raw(array),
+        raw(originalArray),
         raw(firstParam),
         raw(secondParam)
       )
     });
 
-    assert.strictEqual(funcStub.thisValues[0], array);
+    assert.strictEqual(funcStub.thisValues[0], slicedArray);
     assert.deepEqual(funcStub.args, [[firstParam, secondParam]]);
     assert.strictEqual(result, returnValue);
   });

--- a/tests/unit/array/utils/normalize-array-3-test.js
+++ b/tests/unit/array/utils/normalize-array-3-test.js
@@ -22,6 +22,8 @@ let macro;
 module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
   hooks.beforeEach(function() {
     array = emberA([]);
+    sinon.stub(array, 'slice').returns(array);
+
     let obj = EmberObject.create({});
     obj[firstParam] = 1;
     array.push(obj);
@@ -247,6 +249,8 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
     });
 
     array = [];
+    sinon.stub(array, 'slice').returns(array);
+
     funcStub = sinon.stub(array, 'pop').returns(returnValue);
 
     subject.set('array', array);
@@ -334,6 +338,8 @@ module('Unit | Macro | array | utils | normalize array 3', function(hooks) {
 
   test('it handles native arrays', function(assert) {
     array = [];
+    sinon.stub(array, 'slice').returns(array);
+
     funcStub = sinon.stub(array, 'pop').returns(returnValue);
 
     let { result } = compute({


### PR DESCRIPTION
Unfortunately this quirk was introduced by #424 which introduced array normalization to Ember arrays to be able to work with the same interface everywhere.