### PR TITLE
Highlight unexpected behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 * [`getBy`](#getby)
 * [`hash`](#hash)
 * [`isEmpty`](#isempty)
+* [`notEmpty`](#notempty)
 * [`toStr`](#tostr)
 * [`toString`](#tostring)
 * [`typeOf`](#typeof)
@@ -748,6 +749,33 @@ valueObject2: isEmpty('sourceObject2'), // true
 valueObject1: isEmpty(collect(1, 2)), // false
 
 valueObject1: isEmpty([]), // true
+```
+
+##### `notEmpty`
+negation of [`isEmpty`](#isempty)
+
+```js
+sourceString1: '',
+sourceString2: foobar,
+
+sourceArray1: [],
+sourceArray2: [1, 2, 3],
+
+sourceObject1: {},
+sourceObject2: { size: 0 },
+
+valueString1: notEmpty('sourceString1'), // false
+valueString2: notEmpty('sourceString2'), // true
+
+valueArray1: notEmpty('sourceArray1'), // false
+valueArray2: notEmpty('sourceArray2'), // true
+
+valueObject1: notEmpty('sourceObject1'), // true
+valueObject2: notEmpty('sourceObject2'), // false
+
+valueArray3: notEmpty(collect(1, 2)), // true
+
+valueArray4: notEmpty([]) // false
 ```
 
 ##### `instanceOf`

--- a/README.md
+++ b/README.md
@@ -735,7 +735,8 @@ sourceArray1: [],
 sourceArray2: [1, 2, 3],
 
 sourceObject1: {},
-sourceObject2: { size: 0 },
+sourceObject2: { key: "value" },
+sourceObject3: { key: "value", size: 0 },
 
 valueString1: isEmpty('sourceString1'), // true
 valueString2: isEmpty('sourceString2'), // false
@@ -743,12 +744,14 @@ valueString2: isEmpty('sourceString2'), // false
 valueArray1: isEmpty('sourceArray1'), // true
 valueArray2: isEmpty('sourceArray2'), // false
 
-valueObject1: isEmpty('sourceObject1'), // false
-valueObject2: isEmpty('sourceObject2'), // true
+// Note: behaviour for objects might be unexpected
+valueObject1: isEmpty('sourceObject1'), // false (!)
+valueObject2: isEmpty('sourceObject2'), // false
+valueObject3: isEmpty('sourceObject3'), // true (!) 'size' property causes it to behave as an array
 
-valueObject1: isEmpty(collect(1, 2)), // false
+valueArray3: isEmpty(collect(1, 2)), // false
 
-valueObject1: isEmpty([]), // true
+valueArray4: isEmpty([]), // true
 ```
 
 ##### `notEmpty`
@@ -762,7 +765,8 @@ sourceArray1: [],
 sourceArray2: [1, 2, 3],
 
 sourceObject1: {},
-sourceObject2: { size: 0 },
+sourceObject2: { key: "value" },
+sourceObject3: { key: "value", size: 0 },
 
 valueString1: notEmpty('sourceString1'), // false
 valueString2: notEmpty('sourceString2'), // true
@@ -770,8 +774,10 @@ valueString2: notEmpty('sourceString2'), // true
 valueArray1: notEmpty('sourceArray1'), // false
 valueArray2: notEmpty('sourceArray2'), // true
 
-valueObject1: notEmpty('sourceObject1'), // true
-valueObject2: notEmpty('sourceObject2'), // false
+// Note: behaviour for objects might be unexpected
+valueObject1: notEmpty('sourceObject1'), // true (!)
+valueObject2: notEmpty('sourceObject2'), // true
+valueObject3: notEmpty('sourceObject3'), // false (!) 'size' property causes it to behave as an array
 
 valueArray3: notEmpty(collect(1, 2)), // true
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -18,6 +18,7 @@ export { default as hash } from './hash';
 export { default as htmlSafe } from './html-safe';
 export { default as instanceOf } from './instance-of';
 export { default as isEmpty } from './is-empty';
+export { default as notEmpty } from './not-empty';
 export { default as isHtmlSafe } from './is-html-safe';
 export { default as lt } from './lt';
 export { default as lte } from './lte';

--- a/addon/not-empty.js
+++ b/addon/not-empty.js
@@ -1,0 +1,6 @@
+import not from './not';
+import isEmpty from './is-empty';
+
+export default function() {
+  return not(isEmpty(...arguments));
+}

--- a/tests/acceptance/top-level-imports-test.js
+++ b/tests/acceptance/top-level-imports-test.js
@@ -21,6 +21,7 @@ import macros, {
   instanceOf,
   isHtmlSafe,
   isEmpty,
+  notEmpty,
   lt,
   lte,
   math,
@@ -112,6 +113,7 @@ import _htmlSafe from 'ember-awesome-macros/html-safe';
 import _instanceOf from 'ember-awesome-macros/instance-of';
 import _isHtmlSafe from 'ember-awesome-macros/is-html-safe';
 import _isEmpty from 'ember-awesome-macros/is-empty';
+import _notEmpty from 'ember-awesome-macros/not-empty';
 import _lt from 'ember-awesome-macros/lt';
 import _lte from 'ember-awesome-macros/lte';
 import _mod from 'ember-awesome-macros/mod';
@@ -159,6 +161,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(macros.instanceOf);
     assert.ok(macros.isHtmlSafe);
     assert.ok(macros.isEmpty);
+    assert.ok(macros.notEmpty);
     assert.ok(macros.lt);
     assert.ok(macros.lte);
     assert.ok(macros.math);
@@ -255,6 +258,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(instanceOf);
     assert.ok(isHtmlSafe);
     assert.ok(isEmpty);
+    assert.ok(notEmpty);
     assert.ok(lt);
     assert.ok(lte);
     assert.ok(math);
@@ -350,6 +354,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(_instanceOf);
     assert.ok(_isHtmlSafe);
     assert.ok(_isEmpty);
+    assert.ok(_notEmpty);
     assert.ok(_lt);
     assert.ok(_lte);
     assert.ok(_mod);

--- a/tests/integration/is-empty-test.js
+++ b/tests/integration/is-empty-test.js
@@ -109,6 +109,34 @@ module('Integration | Macro | isEmpty', function() {
     });
   });
 
+
+  test('empty with object', function(assert) {
+    compute({
+      assert,
+      computed: isEmpty('source'),
+      properties: {
+        source: {
+          key: 'value'
+        }
+      },
+      strictEqual: false
+    });
+  });
+
+  test('empty with object with size key', function(assert) {
+    compute({
+      assert,
+      computed: isEmpty('source'),
+      properties: {
+        source: {
+          key: 'value',
+          size: 0
+        }
+      },
+      strictEqual: true
+    });
+  });
+
   test('not empty with string', function(assert) {
     compute({
       assert,

--- a/tests/integration/not-empty-test.js
+++ b/tests/integration/not-empty-test.js
@@ -1,0 +1,145 @@
+import { collect, raw } from 'ember-awesome-macros';
+import { notEmpty } from 'ember-awesome-macros';
+import { module, test } from 'qunit';
+import { A as emberA } from '@ember/array';
+import compute from 'ember-macro-test-helpers/compute';
+
+module('Integration | Macro | notEmpty');
+
+test('not empty without params', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty(),
+    properties: {},
+    strictEqual: false
+  });
+});
+
+test('not empty with null', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: null
+    },
+    strictEqual: false
+  });
+});
+
+test('not empty with undefined', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: undefined
+    },
+    strictEqual: false
+  });
+});
+
+test('not empty with empty string', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: ''
+    },
+    strictEqual: false
+  });
+});
+
+test('not empty with empty array', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: []
+    },
+    strictEqual: false
+  });
+});
+
+test('not empty with native empty array', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty([]),
+    strictEqual: false
+  });
+});
+
+test('not empty with native array', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty([1, 2]),
+    strictEqual: true
+  });
+});
+
+test('composing: not empty with raw empty array', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty(raw([])),
+    strictEqual: false
+  });
+});
+
+test('composing: it check if macro result is not empty', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty(collect(1, 2)),
+    strictEqual: true
+  });
+});
+
+test('composing: it check if macro result is not empty', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty(collect()),
+    strictEqual: false
+  });
+});
+
+test('not empty with empty object', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: {}
+    },
+    strictEqual: true
+  });
+});
+
+test('not empty with string', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: 'Adam Hawkins'
+    },
+    strictEqual: true
+  });
+});
+
+test('not empty with array', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: [0, 1, 2]
+    },
+    strictEqual: true
+  });
+});
+
+test('it responds to changes', function(assert) {
+  let array = emberA([]);
+  let { subject } = compute({
+    computed: notEmpty('array'),
+    properties: {
+      array
+    }
+  });
+  array.pushObject(2);
+  assert.strictEqual(subject.get('computed'), true);
+});

--- a/tests/integration/not-empty-test.js
+++ b/tests/integration/not-empty-test.js
@@ -110,6 +110,33 @@ test('not empty with empty object', function(assert) {
   });
 });
 
+test('not empty with object', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: {
+        key: 'value'
+      }
+    },
+    strictEqual: true
+  });
+});
+
+test('not empty with object with size key', function(assert) {
+  compute({
+    assert,
+    computed: notEmpty('source'),
+    properties: {
+      source: {
+        key: 'value',
+        size: 0
+      }
+    },
+    strictEqual: false
+  });
+});
+
 test('not empty with string', function(assert) {
   compute({
     assert,


### PR DESCRIPTION
While working on https://github.com/kellyselden/ember-awesome-macros/pull/512 I found out about some unexpected (for me, at least) behaviour of `isEmpty` w.r.t objects.

I've attempted to highlight these unexpected behaviours in the README, and added tests demonstrating them. I'm happy if you'd rather highlight these in a different way in the README, or if you don't think it's relevant to highlight here.

(This PR is dependent on https://github.com/kellyselden/ember-awesome-macros/pull/512)