### PR TITLE
Add missing boolean operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 * [`not`](#not)
 * [`or`](#or)
 * [`unless`](#unless)
+* [`xor`](#xor)
 
 ##### Comparison
 * [`eq`](#eq)
@@ -1271,6 +1272,17 @@ value2: unless('condition2', 'expr1', 'expr2'), // 'my value 2'
 value3: unless(and('condition1', 'condition2'), raw('my value 1'), raw('my value 2')) // 'my value 1'
 ```
 
+##### `xor`
+applies [`logical XOR`](https://en.wikipedia.org/wiki/logical_XOR) operation
+
+```js
+sourceTrue: true,
+sourceFalse: false,
+
+value1: xor('sourceFalse', 'sourceFalse', 'sourceFalse'), // false
+value2: xor('sourceFalse', 'sourceTrue', 'sourceFalse'), // true
+value3: xor('sourceTrue', 'sourceTrue', 'sourceTrue') // false
+```
 
 Contributing
 ------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 * [`bool`](#bool)
 * [`conditional`](#conditional)
 * [`defaultTrue`](#defaulttrue)
+* [`nand`](#nand)
 * [`not`](#not)
 * [`or`](#or)
 * [`unless`](#unless)
@@ -809,6 +810,18 @@ composingExample: mod(sum('number1', 'number2'), 39) // 12
 
 ##### `multiply`
 alias for [`product`](#product)
+
+##### `nand`
+applies [`logical NAND`](https://en.wikipedia.org/wiki/logical_NAND) operation
+
+```js
+sourceTrue: true,
+sourceFalse: false,
+
+value1: nand('sourceFalse', 'sourceFalse', 'sourceFalse'), // true
+value2: nand('sourceFalse', 'sourceTrue', 'sourceFalse'), // true
+value3: nand('sourceTrue', 'sourceTrue', 'sourceTrue') // false
+```
 
 ##### `neq`
 alias for [`notEqual`](#notequal)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 * [`conditional`](#conditional)
 * [`defaultTrue`](#defaulttrue)
 * [`nand`](#nand)
+* [`nor`](#nor)
 * [`not`](#not)
 * [`or`](#or)
 * [`unless`](#unless)
@@ -825,6 +826,18 @@ value3: nand('sourceTrue', 'sourceTrue', 'sourceTrue') // false
 
 ##### `neq`
 alias for [`notEqual`](#notequal)
+
+##### `nor`
+applies [`logical NOR`](https://en.wikipedia.org/wiki/logical_NOR) operation
+
+```js
+sourceTrue: true,
+sourceFalse: false,
+
+value1: nor('sourceFalse', 'sourceFalse', 'sourceFalse'), // true
+value2: nor('sourceFalse', 'sourceTrue', 'sourceFalse'), // false
+value3: nor('sourceTrue', 'sourceTrue', 'sourceTrue') // false
+```
 
 ##### `not`
 same as `Ember.computed.not`, but allows composing

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ import { nameOfMacro } from 'ember-awesome-macros';
 * [`not`](#not)
 * [`or`](#or)
 * [`unless`](#unless)
+* [`xnor`](#xnor)
 * [`xor`](#xor)
 
 ##### Comparison
@@ -1270,6 +1271,18 @@ expr2: 'my value 2',
 value1: unless('condition1', 'expr1', 'expr2'), // 'my value 1'
 value2: unless('condition2', 'expr1', 'expr2'), // 'my value 2'
 value3: unless(and('condition1', 'condition2'), raw('my value 1'), raw('my value 2')) // 'my value 1'
+```
+
+##### `xnor`
+applies [`logical XNOR`](https://en.wikipedia.org/wiki/logical_XNOR) operation
+
+```js
+sourceTrue: true,
+sourceFalse: false,
+
+value1: xnor('sourceFalse', 'sourceFalse', 'sourceFalse'), // true
+value2: xnor('sourceFalse', 'sourceTrue', 'sourceFalse'), // false
+value3: xnor('sourceTrue', 'sourceTrue', 'sourceTrue') // true
 ```
 
 ##### `xor`

--- a/addon/index.js
+++ b/addon/index.js
@@ -48,6 +48,7 @@ export { default as toString } from './to-string';
 export { default as typeOf } from './type-of';
 export { default as unless } from './unless';
 export { default as writable } from './writable';
+export { default as xnor } from './xnor';
 export { default as xor } from './xor';
 
 import { deprecate } from './-utils';

--- a/addon/index.js
+++ b/addon/index.js
@@ -26,6 +26,7 @@ export { default as mod } from './mod';
 export { default as multiply } from './multiply';
 export { default as nand } from './nand';
 export { default as neq } from './neq';
+export { default as nor } from './nor';
 export { default as not } from './not';
 export { default as notEqual } from './not-equal';
 export { default as number } from './number';

--- a/addon/index.js
+++ b/addon/index.js
@@ -48,6 +48,7 @@ export { default as toString } from './to-string';
 export { default as typeOf } from './type-of';
 export { default as unless } from './unless';
 export { default as writable } from './writable';
+export { default as xor } from './xor';
 
 import { deprecate } from './-utils';
 

--- a/addon/index.js
+++ b/addon/index.js
@@ -24,6 +24,7 @@ export { default as lte } from './lte';
 export { default as math } from './math';
 export { default as mod } from './mod';
 export { default as multiply } from './multiply';
+export { default as nand } from './nand';
 export { default as neq } from './neq';
 export { default as not } from './not';
 export { default as notEqual } from './not-equal';

--- a/addon/nand.js
+++ b/addon/nand.js
@@ -1,0 +1,6 @@
+import not from './not';
+import and from './and';
+
+export default function() {
+  return not(and(...arguments));
+}

--- a/addon/nor.js
+++ b/addon/nor.js
@@ -1,0 +1,6 @@
+import not from './not';
+import or from './or';
+
+export default function() {
+  return not(or(...arguments));
+}

--- a/addon/xnor.js
+++ b/addon/xnor.js
@@ -1,0 +1,6 @@
+import not from './not';
+import xor from './xor';
+
+export default function() {
+  return not(xor(...arguments));
+}

--- a/addon/xor.js
+++ b/addon/xor.js
@@ -1,10 +1,10 @@
 import and from './and';
-import not from './not';
+import nand from './nand';
 import or from './or';
 
 export default function() {
   return and(
     or(...arguments),
-    not(and(...arguments))
+    nand(...arguments)
   );
 }

--- a/addon/xor.js
+++ b/addon/xor.js
@@ -1,0 +1,10 @@
+import and from './and';
+import not from './not';
+import or from './or';
+
+export default function() {
+  return and(
+    or(...arguments),
+    not(and(...arguments))
+  );
+}

--- a/tests/acceptance/top-level-imports-test.js
+++ b/tests/acceptance/top-level-imports-test.js
@@ -26,6 +26,7 @@ import macros, {
   math,
   mod,
   multiply,
+  nand,
   neq,
   not,
   notEqual,
@@ -116,6 +117,7 @@ import _lt from 'ember-awesome-macros/lt';
 import _lte from 'ember-awesome-macros/lte';
 import _mod from 'ember-awesome-macros/mod';
 import _multiply from 'ember-awesome-macros/multiply';
+import _nand from 'ember-awesome-macros/nand';
 import _neq from 'ember-awesome-macros/neq';
 import _not from 'ember-awesome-macros/not';
 import _notEqual from 'ember-awesome-macros/not-equal';
@@ -164,6 +166,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(macros.math);
     assert.ok(macros.mod);
     assert.ok(macros.multiply);
+    assert.ok(macros.nand);
     assert.ok(macros.neq);
     assert.ok(macros.not);
     assert.ok(macros.notEqual);
@@ -260,6 +263,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(math);
     assert.ok(mod);
     assert.ok(multiply);
+    assert.ok(nand);
     assert.ok(neq);
     assert.ok(not);
     assert.ok(notEqual);
@@ -354,6 +358,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(_lte);
     assert.ok(_mod);
     assert.ok(_multiply);
+    assert.ok(_nand);
     assert.ok(_neq);
     assert.ok(_not);
     assert.ok(_notEqual);

--- a/tests/acceptance/top-level-imports-test.js
+++ b/tests/acceptance/top-level-imports-test.js
@@ -48,6 +48,7 @@ import macros, {
   typeOf,
   unless,
   writable,
+  xor,
 
   // deprecations
 
@@ -138,6 +139,7 @@ import _toString from 'ember-awesome-macros/to-string';
 import _typeOf from 'ember-awesome-macros/type-of';
 import _unless from 'ember-awesome-macros/unless';
 import _writable from 'ember-awesome-macros/writable';
+import _xor from 'ember-awesome-macros/xor';
 
 module('Acceptance | top level imports', function() {
   test('all top level global imports', function(assert) {
@@ -190,6 +192,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(macros.typeOf);
     assert.ok(macros.unless);
     assert.ok(macros.writable);
+    assert.ok(macros.xor);
 
     // deprecations
 
@@ -288,6 +291,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(typeOf);
     assert.ok(unless);
     assert.ok(writable);
+    assert.ok(xor);
 
     // deprecations
 
@@ -382,5 +386,6 @@ module('Acceptance | top level imports', function() {
     assert.ok(_typeOf);
     assert.ok(_unless);
     assert.ok(_writable);
+    assert.ok(_xor);
   });
 });

--- a/tests/acceptance/top-level-imports-test.js
+++ b/tests/acceptance/top-level-imports-test.js
@@ -28,6 +28,7 @@ import macros, {
   multiply,
   nand,
   neq,
+  nor,
   not,
   notEqual,
   number,
@@ -119,6 +120,7 @@ import _mod from 'ember-awesome-macros/mod';
 import _multiply from 'ember-awesome-macros/multiply';
 import _nand from 'ember-awesome-macros/nand';
 import _neq from 'ember-awesome-macros/neq';
+import _nor from 'ember-awesome-macros/nor';
 import _not from 'ember-awesome-macros/not';
 import _notEqual from 'ember-awesome-macros/not-equal';
 import _number from 'ember-awesome-macros/number';
@@ -168,6 +170,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(macros.multiply);
     assert.ok(macros.nand);
     assert.ok(macros.neq);
+    assert.ok(macros.nor);
     assert.ok(macros.not);
     assert.ok(macros.notEqual);
     assert.ok(macros.number);
@@ -265,6 +268,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(multiply);
     assert.ok(nand);
     assert.ok(neq);
+    assert.ok(nor);
     assert.ok(not);
     assert.ok(notEqual);
     assert.ok(number);
@@ -360,6 +364,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(_multiply);
     assert.ok(_nand);
     assert.ok(_neq);
+    assert.ok(_nor);
     assert.ok(_not);
     assert.ok(_notEqual);
     assert.ok(_number);

--- a/tests/acceptance/top-level-imports-test.js
+++ b/tests/acceptance/top-level-imports-test.js
@@ -48,6 +48,7 @@ import macros, {
   typeOf,
   unless,
   writable,
+  xnor,
   xor,
 
   // deprecations
@@ -139,6 +140,7 @@ import _toString from 'ember-awesome-macros/to-string';
 import _typeOf from 'ember-awesome-macros/type-of';
 import _unless from 'ember-awesome-macros/unless';
 import _writable from 'ember-awesome-macros/writable';
+import _xnor from 'ember-awesome-macros/xnor';
 import _xor from 'ember-awesome-macros/xor';
 
 module('Acceptance | top level imports', function() {
@@ -192,6 +194,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(macros.typeOf);
     assert.ok(macros.unless);
     assert.ok(macros.writable);
+    assert.ok(macros.xnor);
     assert.ok(macros.xor);
 
     // deprecations
@@ -291,6 +294,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(typeOf);
     assert.ok(unless);
     assert.ok(writable);
+    assert.ok(xnor);
     assert.ok(xor);
 
     // deprecations
@@ -386,6 +390,7 @@ module('Acceptance | top level imports', function() {
     assert.ok(_typeOf);
     assert.ok(_unless);
     assert.ok(_writable);
+    assert.ok(_xnor);
     assert.ok(_xor);
   });
 });

--- a/tests/integration/nand-test.js
+++ b/tests/integration/nand-test.js
@@ -1,0 +1,44 @@
+import { nand } from 'ember-awesome-macros';
+import { module, test } from 'qunit';
+import { compute } from 'ember-macro-test-helpers';
+
+module('Integration | Macro | nand', function() {
+  test('all false returns true', function(assert) {
+    compute({
+      assert,
+      computed: nand('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: false,
+        source3: false
+      },
+      strictEqual: true
+    });
+  });
+
+  test('mixed values returns true', function(assert) {
+    compute({
+      assert,
+      computed: nand('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: true,
+        source3: false
+      },
+      strictEqual: true
+    });
+  });
+
+  test('all true returns false', function(assert) {
+    compute({
+      assert,
+      computed: nand('source1', 'source2', 'source3'),
+      properties: {
+        source1: true,
+        source2: true,
+        source3: true
+      },
+      strictEqual: false
+    });
+  });
+});

--- a/tests/integration/nor-test.js
+++ b/tests/integration/nor-test.js
@@ -1,0 +1,44 @@
+import { nor } from 'ember-awesome-macros';
+import { module, test } from 'qunit';
+import { compute } from 'ember-macro-test-helpers';
+
+module('Integration | Macro | nor', function() {
+  test('all false returns true', function(assert) {
+    compute({
+      assert,
+      computed: nor('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: false,
+        source3: false
+      },
+      strictEqual: true
+    });
+  });
+
+  test('mixed values returns false', function(assert) {
+    compute({
+      assert,
+      computed: nor('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: true,
+        source3: false
+      },
+      strictEqual: false
+    });
+  });
+
+  test('all true returns false', function(assert) {
+    compute({
+      assert,
+      computed: nor('source1', 'source2', 'source3'),
+      properties: {
+        source1: true,
+        source2: true,
+        source3: true
+      },
+      strictEqual: false
+    });
+  });
+});

--- a/tests/integration/xnor-test.js
+++ b/tests/integration/xnor-test.js
@@ -1,0 +1,44 @@
+import { xnor } from 'ember-awesome-macros';
+import { module, test } from 'qunit';
+import { compute } from 'ember-macro-test-helpers';
+
+module('Integration | Macro | xnor', function() {
+  test('all false returns true', function(assert) {
+    compute({
+      assert,
+      computed: xnor('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: false,
+        source3: false
+      },
+      strictEqual: true
+    });
+  });
+
+  test('mixed values returns false', function(assert) {
+    compute({
+      assert,
+      computed: xnor('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: true,
+        source3: false
+      },
+      strictEqual: false
+    });
+  });
+
+  test('all true returns true', function(assert) {
+    compute({
+      assert,
+      computed: xnor('source1', 'source2', 'source3'),
+      properties: {
+        source1: true,
+        source2: true,
+        source3: true
+      },
+      strictEqual: true
+    });
+  });
+});

--- a/tests/integration/xor-test.js
+++ b/tests/integration/xor-test.js
@@ -1,0 +1,44 @@
+import { xor } from 'ember-awesome-macros';
+import { module, test } from 'qunit';
+import { compute } from 'ember-macro-test-helpers';
+
+module('Integration | Macro | xor', function() {
+  test('all false returns false', function(assert) {
+    compute({
+      assert,
+      computed: xor('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: false,
+        source3: false
+      },
+      strictEqual: false
+    });
+  });
+
+  test('mixed values returns true', function(assert) {
+    compute({
+      assert,
+      computed: xor('source1', 'source2', 'source3'),
+      properties: {
+        source1: false,
+        source2: true,
+        source3: false
+      },
+      strictEqual: true
+    });
+  });
+
+  test('all true returns false', function(assert) {
+    compute({
+      assert,
+      computed: xor('source1', 'source2', 'source3'),
+      properties: {
+        source1: true,
+        source2: true,
+        source3: true
+      },
+      strictEqual: false
+    });
+  });
+});


### PR DESCRIPTION
Adds `nand`, `nor`, `xor` and `xnor` macros.

Ref #446